### PR TITLE
chore: don't show a warning about using useLayoutEffect in SSR

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,7 @@
 [*]
 max_line_length = 120
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+quote_type = double

--- a/src/useEvent.ts
+++ b/src/useEvent.ts
@@ -3,6 +3,12 @@ import { useLayoutEffect, useRef } from "react";
 type AnyFunction = (...args: any[]) => any;
 
 /**
+ * This is to fix a warning when using useLayoutEffect on server
+ * https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
+ */
+const useBrowserLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : () => {};
+
+/**
  * Similar to useCallback, with a few subtle differences:
  * - The returned function is a stable reference, and will always be the same between renders
  * - No dependency lists required
@@ -11,7 +17,7 @@ type AnyFunction = (...args: any[]) => any;
 export function useEvent<TCallback extends AnyFunction>(callback: TCallback): TCallback {
   // Keep track of the latest callback:
   const latestRef = useRef<TCallback>(useEventResultShouldNotBeCalledDuringRender as any);
-  useLayoutEffect(() => {
+  useBrowserLayoutEffect(() => {
     latestRef.current = callback;
   }, [callback]);
 

--- a/src/useEvent.ts
+++ b/src/useEvent.ts
@@ -3,7 +3,7 @@ import { useLayoutEffect, useRef } from "react";
 type AnyFunction = (...args: any[]) => any;
 
 /**
- * Fixes a warning when using useLayoutEffect on server
+ * Suppress the warning when using useLayoutEffect with SSR
  * https://reactjs.org/link/uselayouteffect-ssr
  */
 const useBrowserLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : () => {};
@@ -16,7 +16,7 @@ const useBrowserLayoutEffect = typeof window !== "undefined" ? useLayoutEffect :
  */
 export function useEvent<TCallback extends AnyFunction>(callback: TCallback): TCallback {
   // Keep track of the latest callback:
-  const latestRef = useRef<TCallback>(useEventResultShouldNotBeCalledDuringRender as any);
+  const latestRef = useRef<TCallback>(useEvent_shouldNotBeInvokedBeforeMount as any);
   useBrowserLayoutEffect(() => {
     latestRef.current = callback;
   }, [callback]);
@@ -36,9 +36,9 @@ export function useEvent<TCallback extends AnyFunction>(callback: TCallback): TC
  * Render methods should be pure, especially when concurrency is used,
  * so we will throw this error if the callback is called while rendering.
  */
-function useEventResultShouldNotBeCalledDuringRender() {
+function useEvent_shouldNotBeInvokedBeforeMount() {
   throw new Error(
-    "The callback from useEvent cannot be called while rendering; it should be wrapped in `useEffect` or `useLayoutEffect`."
+    "INVALID_USEEVENT_INVOCATION: the callback from useEvent cannot be invoked before the component has mounted."
   );
 }
 

--- a/src/useEvent.ts
+++ b/src/useEvent.ts
@@ -3,7 +3,7 @@ import { useLayoutEffect, useRef } from "react";
 type AnyFunction = (...args: any[]) => any;
 
 /**
- * This is to fix a warning when using useLayoutEffect on server
+ * Fixes a warning when using useLayoutEffect on server
  * https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
  */
 const useBrowserLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : () => {};

--- a/src/useEvent.ts
+++ b/src/useEvent.ts
@@ -4,7 +4,7 @@ type AnyFunction = (...args: any[]) => any;
 
 /**
  * Fixes a warning when using useLayoutEffect on server
- * https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
+ * https://reactjs.org/link/uselayouteffect-ssr
  */
 const useBrowserLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : () => {};
 


### PR DESCRIPTION
This PR fixes a warning when using useEvent in SSR:

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
