### PR TITLE
Support ESM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - npm run test:react-18
           - npm run test:react-17
           - npm run lint
-          - npm run build:check
+          - npm run typecheck
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -2,25 +2,29 @@
   "name": "react-use-event-hook",
   "version": "0.9.2",
   "description": "Same as React's `useCallback`, but returns a stable reference.",
-  "main": "dist/useEvent.js",
+  "main": "dist/cjs/useEvent.js",
+  "module": "dist/esm/useEvent.js",
+  "types": "dist/esm/useEvent.d.ts",
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
-    "check": "npm run lint && npm run build:check && npm run test:react-18 && npm run test:react-17",
+    "check": "npm run lint && npm run typecheck && npm run test:react-18 && npm run test:react-17",
     "test": "jest",
     "test:react-18": "jest",
     "test:react-17": "cd test/react-17; test -d node_modules || npm ci; npm run test",
     "test:watch": "jest --watch",
     "lint": "prettier src --check",
     "lint:fix": "prettier src --write",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --outDir dist/cjs --module commonjs",
     "clean": "rimraf dist",
     "build:watch": "tsc --watch",
-    "build:check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build",
-    "preversion": "npm run test && npm run build:check"
+    "preversion": "npm run test && npm run typecheck"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "ES2020",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "ES2020",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -14,7 +14,7 @@
      // "declarationMap": true,               /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "dist",                         /* Redirect output structure to the directory. */
+    "outDir": "dist/esm",                         /* Redirect output structure to the directory. */
     "rootDir": "src",                         /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -52,7 +52,7 @@
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-    "resolveJsonModule": true,
+    // "resolveJsonModule": true,
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
@@ -69,6 +69,7 @@
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   },
   "exclude": [
-    "**/*.test.*"
+    "**/*.test*",
+    "dist/**"
   ]
 }


### PR DESCRIPTION
# What
- Adds ESM output to package.
- Updates TS target to ES2020. Basically, fat arrow functions are no longer converted

Replaces #9 